### PR TITLE
docs: Fix broken community banner image

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 # nhcommunity
 
-![community banner](banner.png)
+![community banner](https://raw.githubusercontent.com/nhcommunity/.github/main/banner.png)
 
 Welcome to our community organisation! This is where we store our community projects, such as our home page and handbook.
 


### PR DESCRIPTION
# Pull Request

## Description:

• Fixes community banner image which shows broken on GitHub Mobile application. 

# Test Example:

## Before:

![Screenshot_2022-01-31-22-12-56-476_com github android](https://user-images.githubusercontent.com/80174214/151837621-8fadfaee-2579-4cf3-a7ab-6c2abb9cf0a4.jpg)


## After:

![Screenshot_2022-01-31-22-19-08-031_com github android](https://user-images.githubusercontent.com/80174214/151837676-0a2d5ee2-9221-4474-b52c-ae2bce34d580.jpg)

